### PR TITLE
Add test for 15-character ID record mentions

### DIFF
--- a/force-app/main/default/classes/ConnectApiHelper.cls
+++ b/force-app/main/default/classes/ConnectApiHelper.cls
@@ -291,7 +291,7 @@ global class ConnectApiHelper {
         input.messageSegments = new List<ConnectApi.MessageSegmentInput>();
         
         // Identify newline and replace it with encoded values that MessageSegment will handle correctly.
-        string newline = EncodingUtil.urlDecode('%0A', 'UTF-8'); 
+        String newline = EncodingUtil.urlDecode('%0A', 'UTF-8'); 
 
         for (ConnectApi.MessageSegment segment : body.messageSegments) {
             if (segment instanceof ConnectApi.TextSegment) {
@@ -300,8 +300,8 @@ global class ConnectApiHelper {
                     // If newline is found, create multiple message segments instead of just a textSegment.
                     List<ConnectApi.MessageSegmentInput> newSegments = 
                         ConnectApiHelper.getMessageSegmentInputs(textOutput.text
-                                        .replaceAll(newline+newline,'<p>&nbsp;</p>')
-                                        .replaceAll(newline,'<p></p>'));
+                                        .replaceAll(newline + newline, '<p>&nbsp;</p>')
+                                        .replaceAll(newline, '<p></p>'));
                     input.messageSegments.addAll(newSegments);
                 }
                 else {

--- a/force-app/main/default/classes/ConnectApiHelperTest.cls
+++ b/force-app/main/default/classes/ConnectApiHelperTest.cls
@@ -325,7 +325,7 @@ public class ConnectApiHelperTest {
 
         // Mock up an text segment containing a newline character.
         ConnectApi.TextSegment textSegment = new ConnectApi.TextSegment();
-        string newline = EncodingUtil.urlDecode('%0A', 'UTF-8'); 
+        String newline = EncodingUtil.urlDecode('%0A', 'UTF-8'); 
         textSegment.text = 'foo' + newline + 'bar';
 
         body.messageSegments.add(textSegment);
@@ -354,7 +354,7 @@ public class ConnectApiHelperTest {
 
         // Mock up an text segment containing a newline character.
         ConnectApi.TextSegment textSegment = new ConnectApi.TextSegment();
-        string newline = EncodingUtil.urlDecode('%0A', 'UTF-8'); 
+        String newline = EncodingUtil.urlDecode('%0A', 'UTF-8'); 
         textSegment.text = 'foo' + newline + newline + 'bar';
 
         body.messageSegments.add(textSegment);

--- a/force-app/main/default/classes/ConnectApiHelperTest.cls
+++ b/force-app/main/default/classes/ConnectApiHelperTest.cls
@@ -29,8 +29,8 @@ OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  * Unit tests for ConnectApiHelper.
  *
- * This class works with API version 36.0 and later. There are separate classes
- * that work with v35.0 and earlier.
+ * This class works with API version 43.0 and later. There are separate classes
+ * that work with v42.0 and earlier.
  *
  * See https://github.com/forcedotcom/ConnectApiHelper for more information.
  *
@@ -558,8 +558,21 @@ public class ConnectApiHelperTest {
     }
 
     @IsTest(SeeAllData=true)
-    static void testRecordMention() {
+    static void testRecordMention18CharId() {
         String recordId = '01t3E000002GCm9QAG';
+        String text = '{record:' + recordId + '}';
+        List<ConnectApi.MessageSegmentInput> segments = ConnectApiHelper.getMessageSegmentInputs(text);
+
+        System.assertEquals(1, segments.size());
+        System.assert(segments.get(0) instanceof ConnectApi.EntityLinkSegmentInput);
+
+        ConnectApi.EntityLinkSegmentInput recordSegment = (ConnectApi.EntityLinkSegmentInput) segments.get(0);
+        System.assertEquals(recordId, recordSegment.entityId);
+    }
+
+    @IsTest(SeeAllData=true)
+    static void testRecordMention15CharId() {
+        String recordId = '01t3E000002GCm9';
         String text = '{record:' + recordId + '}';
         List<ConnectApi.MessageSegmentInput> segments = ConnectApiHelper.getMessageSegmentInputs(text);
 


### PR DESCRIPTION
There was an existing test for 18-character record IDs, but not for 15-character ones.

Also fix some code formatting.